### PR TITLE
Fix Error 'Contract can't be hashed'

### DIFF
--- a/ib_async/client.py
+++ b/ib_async/client.py
@@ -248,11 +248,18 @@ class Client:
         if not self.isConnected():
             raise ConnectionError("Not connected")
 
+        def is_field_hashable(field):
+            try:
+                hash(field)
+                return True
+            except Exception:
+                return False
+
         msg = io.StringIO()
         empty = {None, UNSET_INTEGER, UNSET_DOUBLE} if makeEmpty else {None}
         for field in fields:
             typ = type(field)
-            if field in empty:
+            if is_field_hashable(field) and field in empty:
                 s = ""
             elif typ is str:
                 s = field


### PR DESCRIPTION
The set membership test in 
https://github.com/ib-api-reloaded/ib_async/blob/0ae43453b05345e3d21be518dcedb4dda6cb019f/ib_async/client.py#L255-L256

requires `field` to be hashable. When `qualifyContracts` is first called, a new contract object is passed in as `field`, and it is not yet hashable since the contract is not yet qualified.

The old `ib_insync` library did not have this issue as it used a tuple instead of a set.

Fix: Guard the membership test by first testing whether `field` is hashable.

Closes #4

ps. Thank you for continuing the work of `ib_insync`. It means a lot to me.