### PR TITLE
Fixes minor linking errors

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -6,5 +6,5 @@ Source code
 .. toctree::
    :maxdepth: 2
 
-   Download <https://github.com/erdewit/ib_async>
-   Issue Tracker <https://github.com/erdewit/ib_async/issues>
+   Download <https://github.com/ib-api-reloaded/ib_async>
+   Issue Tracker <https://github.com/ib-api-reloaded/ib_async/issues>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
 ]
-keywords = ["ibapi", "tws", "asyncio", "jupyter", "interactive", "brokers", "async", "ib_insync"]
+keywords = ["ibapi", "tws", "asyncio", "jupyter", "interactive", "brokers", "async", "ib_async", "ib_insync"]
 
 [tool.poetry.dependencies]
 python = ">=3.10"


### PR DESCRIPTION
Updates a few links that pointed to the now deprecated [`ib_insync`](https://github.com/erdewit/ib_insync) API.

Resolves #7