### PR TITLE
Fix notebook documentation

### DIFF
--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -10,13 +10,13 @@ Here are some recipe notebooks:
 .. toctree::
    :maxdepth: 2
 
-   Basics <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/master/notebooks/basics.ipynb>
-   Contract details <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/master/notebooks/contract_details.ipynb>
-   Option chain <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/master/notebooks/option_chain.ipynb>
-   Bar data <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/master/notebooks/bar_data.ipynb>
-   Tick data <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/master/notebooks/tick_data.ipynb>
-   Market depth <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/master/notebooks/market_depth.ipynb>
-   Ordering <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/master/notebooks/ordering.ipynb>
-   Scanners <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/master/notebooks/scanners.ipynb>
+   Basics <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/main/notebooks/basics.ipynb>
+   Contract details <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/main/notebooks/contract_details.ipynb>
+   Option chain <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/main/notebooks/option_chain.ipynb>
+   Bar data <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/main/notebooks/bar_data.ipynb>
+   Tick data <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/main/notebooks/tick_data.ipynb>
+   Market depth <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/main/notebooks/market_depth.ipynb>
+   Ordering <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/main/notebooks/ordering.ipynb>
+   Scanners <https://nbviewer.jupyter.org/github/ib-api-reloaded/ib_async/tree/main/notebooks/scanners.ipynb>
 
 


### PR DESCRIPTION
All link on notebooks documentation are broken.

After checking the code i can see that all links point to master branch, which is the branch used by ib_insync, however this repo uses main.

issue https://github.com/ib-api-reloaded/ib_async/issues/10
