### PR TITLE
Check contract details has time zone ID

### DIFF
--- a/ib_async/contract.py
+++ b/ib_async/contract.py
@@ -582,19 +582,15 @@ class ContractDetails:
         return self._parseSessions(self.liquidHours)
 
     def _parseSessions(self, s: str) -> List[TradingSession]:
-        tz = util.ZoneInfo(self.timeZoneId)
         sessions = []
-        for sess in s.split(";"):
-            if not sess or "CLOSED" in sess:
-                continue
-            sessions.append(
-                TradingSession(
-                    *[
-                        dt.datetime.strptime(t, "%Y%m%d:%H%M").replace(tzinfo=tz)
-                        for t in sess.split("-")
-                    ]
-                )
-            )
+        if s:
+            tz = util.ZoneInfo(self.timeZoneId)
+            for sess in s.split(";"):
+                if not sess or 'CLOSED' in sess:
+                    continue
+                sessions.append(TradingSession(*[
+                    dt.datetime.strptime(t, "%Y%m%d:%H%M").replace(tzinfo=tz)
+                    for t in sess.split("-")]))
         return sessions
 
 


### PR DESCRIPTION
Contracts about to expire may not have tradingHours, liquidHours, and timeZoneId set. This was causing an error when _parseSessions is called:
```bash
Exception has occurred: ValueError
ZoneInfo keys must be normalized relative paths, got: 
```
A simple way to avoid the error would be to check if the argument string is empty.