### PR TITLE
Updating ib.reqPnL method to avoid AssertionError in case of repetitive calls

### DIFF
--- a/ib_async/ib.py
+++ b/ib_async/ib.py
@@ -973,7 +973,8 @@ class IB:
 
     def reqPnL(self, account: str, modelCode: str = "") -> PnL:
         """
-        Start a subscription for profit and loss events.
+        Start a subscription for profit and loss events if 
+        not subscribed already.
 
         Returns a :class:`.PnL` object that is kept live updated.
         The result can also be queried from :meth:`.pnl`.
@@ -985,15 +986,17 @@ class IB:
             modelCode: If specified, filter for this account model.
         """
         key = (account, modelCode)
-        assert key not in self.wrapper.pnlKey2ReqId
-
-        reqId = self.client.getReqId()
-        self.wrapper.pnlKey2ReqId[key] = reqId
-        pnl = PnL(account, modelCode)
-        self.wrapper.reqId2PnL[reqId] = pnl
-        self.client.reqPnL(reqId, account, modelCode)
-
-        return pnl
+        if key not in self.wrapper.pnlKey2ReqId:
+            reqId = self.client.getReqId()
+            self.wrapper.pnlKey2ReqId[key] = reqId
+            pnl = PnL(account, modelCode)
+            self.wrapper.reqId2PnL[reqId] = pnl
+            self.client.reqPnL(reqId, account, modelCode)
+            return pnl
+        else:
+            reqId = self.wrapper.pnlKey2ReqId[key]
+            pnl = self.wrapper.reqId2PnL[reqId]
+            return pnl
 
     def cancelPnL(self, account, modelCode: str = ""):
         """


### PR DESCRIPTION

Earlier, an assert statement `assert key not in self.wrapper.pnlKey2ReqId` was causing the `AssertionError` when `reqPnL` is called second time for same set of inputs. This update avoids the error and returns existing `PnL` class object if already subscribed.

Minimum reproducible example

```python
from ib_async import IB
import time
ib = IB()
account = "DUXXXXXXX"
ib.connect(clientId=5)
ib.sleep()
data=ib.reqPnL(account)
ib.sleep()
#Do something with data and for whatever reason, call ib.reqPnL again
data = ib.reqPnL(account) #This line causes the error
ib.sleep()
```

This creates error as follows

```
Traceback (most recent call last):
  File "C:\Users\Administrator\Desktop\algoBot\pnlTrial.py", line 11, in <module>
    data = ib.reqPnL(account)
           ^^^^^^^^^^^^^^^^^^
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python312\Lib\site-packages\ib_async\ib.py", line 951, in reqPnL
    assert key not in self.wrapper.pnlKey2ReqId
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Even though calling `ib.reqPnL()` multiple times is not a sensible choice, this can be done accidentally by someone assuming `ib.reqPnL` to have same behavior as `reqMktData` or other requests. These other request methods generate no error and hence the `reqPnL` should also be consistent with other methods. 

Hence, proposing the change. 