### PR TITLE
add SNAP MID order type and usage example

### DIFF
--- a/examples/place-order-snap-mid.py
+++ b/examples/place-order-snap-mid.py
@@ -1,0 +1,48 @@
+from ib_async import IB, Future, SnapMidOrder, TimeCondition
+from datetime import datetime, timedelta, timezone
+
+ib = IB()
+ib.connect(
+    host = "127.0.0.1",
+    port = 7497,
+    clientId = 1
+)
+
+# Define the ES futures contract (E-mini S&P 500 Futures)
+# SNAP MID orders are mostly used to make better-than MKT fill
+# for highly liquid instruments, but those which don't support
+# more sophisticated IB order types.
+# Common example is Futures/CFD
+contract = Future(
+    symbol = "ES",
+    lastTradeDateOrContractMonth = "20250321",   # use actual expiration date
+    exchange = "CME"
+)
+
+# Define an execution condition for order - some time in future
+# to make sure order is not executed immediately (for testing purposes)
+future_date = datetime.now(timezone.utc) + timedelta(days = 10)
+time_condition = TimeCondition(
+    time = future_date.strftime("%Y%m%d %H:%M:%S UTC")
+)
+
+# Create order object
+order = SnapMidOrder(
+    action = "BUY",
+    totalQuantity = 1,
+    conditions = [
+        time_condition
+    ]
+)
+
+# Place the order with the time condition
+print("Placing order...")
+trade = ib.placeOrder(contract, order)
+
+print("waiting a bit...")
+ib.sleep(1)
+
+print("Order placed")
+print(f"status: {trade.orderStatus.status}")
+
+ib.disconnect()

--- a/ib_async/__init__.py
+++ b/ib_async/__init__.py
@@ -195,6 +195,7 @@ __all__ = [
     "OrderStatus",
     "PercentChangeCondition",
     "PriceCondition",
+    "SnapMidOrder",
     "StopLimitOrder",
     "StopOrder",
     "TimeCondition",

--- a/ib_async/__init__.py
+++ b/ib_async/__init__.py
@@ -95,6 +95,7 @@ from .order import (
     OrderStatus,
     PercentChangeCondition,
     PriceCondition,
+    SnapMidOrder,
     StopLimitOrder,
     StopOrder,
     TimeCondition,

--- a/ib_async/order.py
+++ b/ib_async/order.py
@@ -196,6 +196,13 @@ class MarketOrder(Order):
         )
 
 
+class SnapMidOrder(Order):
+    def __init__(self, action: str, totalQuantity: float, **kwargs):
+        Order.__init__(
+            self, orderType="SNAP MID", action=action, totalQuantity=totalQuantity, **kwargs
+        )
+
+
 class StopOrder(Order):
     def __init__(self, action: str, totalQuantity: float, stopPrice: float, **kwargs):
         Order.__init__(


### PR DESCRIPTION
Add SNAP MID order type, quite simple one.

I noticed that other order-type classes were suggested, and I wanted to respond to [this comment](https://github.com/ib-api-reloaded/ib_async/pull/14#issuecomment-2159119576).

The primary goal of this library, as stated in the README, is "to make working with the Trader Workstation API from Interactive Brokers as easy as possible." If the library doesn’t support the various order types directly, people using it will be forced to write additional wrappers themselves to handle these order types, which could result in less readable code. This goes against the library's core intent. After all, ibapi already provides the raw interface to the IB API, and the real value of ib_async lies in simplifying that interface and making it more human-friendly.

To ensure these new classes are helpful, a few points should be addressed:
- The constructor should define a minimum set of required arguments (similar to how existing order-type classes are structured).
- Ideally, an example of how to use the new classes should be included to demonstrate their intended usage.

I’ve made both of these changes in the pull request.