### PR TITLE
fixed ib_async.wrapper ERROR for tickType 88 and 90

### DIFF
--- a/ib_async/wrapper.py
+++ b/ib_async/wrapper.py
@@ -1113,7 +1113,7 @@ class Wrapper:
                 ticker.askExchange = value
             elif tickType == 84:
                 ticker.lastExchange = value
-            elif tickType == 45:
+            elif tickType in {45, 88}:
                 timestamp = int(value)
 
                 # only populate if timestamp isn't '0' (we don't want to report "last trade: 20,000 days ago")

--- a/ib_async/wrapper.py
+++ b/ib_async/wrapper.py
@@ -133,6 +133,7 @@ GENERIC_TICK_MAP: Final[TickDict] = {
     55: "tradeRate",
     56: "volumeRate",
     58: "rtHistVolatility",
+    90: "ShortableStatus",
 }
 
 GREEKS_TICK_MAP: Final[TickDict] = {


### PR DESCRIPTION
During the execution found numerous errors:
ib_async.wrapper ERROR: tickString with tickType 88: unhandled value: '1763653969'

Due to unhandled tickType 88

as well tickType 90 was unhandled :
AssertionError: Received tick tickType=90 value=0 but we don't have an attribute mapping for it? Triggered from ticker.contract=Stock(conId=4817283, symbol='RCMT', exchange='NASDAQ', currency='USD', localSymbol='RCMT', tradingClass='NMS')
2025-11-20 17:00:16,731 ib_async.Decoder ERROR: Error for tickGeneric([796, 90, 0.0]):
Traceback (most recent call last):
  File "/home/opc/.local/lib/python3.11/site-packages/ib_async/decoder.py", line 170, in handler
    method(*args)
  File "/home/opc/.local/lib/python3.11/site-packages/ib_async/wrapper.py", line 1208, in tickGeneric
    assert tickType in GENERIC_TICK_MAP, (