### PR TITLE
nest-asyncio2 - fix for py314

### DIFF
--- a/ib_async/util.py
+++ b/ib_async/util.py
@@ -476,9 +476,9 @@ async def waitUntilAsync(t: Time_t) -> bool:
 
 def patchAsyncio():
     """Patch asyncio to allow nested event loops."""
-    import nest_asyncio
+    import nest_asyncio2
 
-    nest_asyncio.apply()
+    nest_asyncio2.apply()
 
 
 def getLoop():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ keywords = ["ibapi", "tws", "asyncio", "jupyter", "interactive", "brokers", "asy
 python = ">=3.10"
 aeventkit = "^2.1.0"
 # aeventkit = { path = "../eventkit", develop = true }
-nest_asyncio = "*"
+nest-asyncio2 = "*"
 tzdata = "^2025.2"
 
 [tool.poetry.urls]


### PR DESCRIPTION
fix: upgrade nest_asyncio to nest-asyncio2 to support p314. Tested ipython, and all examples (qt & tk) are working fine with nest-asyncio2

fix for #200 