### PR TITLE
Type the return type of connect{Async}

### DIFF
--- a/ib_async/ib.py
+++ b/ib_async/ib.py
@@ -347,7 +347,7 @@ class IB:
         account: str = "",
         raiseSyncErrors: bool = False,
         fetchFields: StartupFetch = StartupFetchALL,
-    ):
+    ) -> 'IB':
         """
         Connect to a running TWS or IB gateway application.
         After the connection is made the client is fully synchronized
@@ -2044,7 +2044,7 @@ class IB:
         account: str = "",
         raiseSyncErrors: bool = False,
         fetchFields: StartupFetch = StartupFetchALL,
-    ):
+    ) -> 'IB':
         clientId = int(clientId)
         self.wrapper.clientId = clientId
         timeout = timeout or None


### PR DESCRIPTION
The type was omitted which causes issues downstream if the typechecker is set in strict mode.

Since the return type references the class being
created, we need to use forward references:
https://peps.python.org/pep-0484/#forward-references