### PR TITLE
fix: drop misc-options count field in calculate{ImpliedVolatility,OptionPrice} (fixes #222, #170)

### DIFF
--- a/ib_async/client.py
+++ b/ib_async/client.py
@@ -953,7 +953,6 @@ class Client:
             contract,
             optionPrice,
             underPrice,
-            len(implVolOptions),
             implVolOptions,
         )
 
@@ -967,7 +966,6 @@ class Client:
             contract,
             volatility,
             underPrice,
-            len(optPrcOptions),
             optPrcOptions,
         )
 


### PR DESCRIPTION
Both `Client.calculateImpliedVolatility` and `Client.calculateOptionPrice` send a `len(...)` count field before the misc-options list. Current gateways reject this with **error 320** ("Please use 'Key=Value' format for Misc Options") — the server reads the count where it expects the options string — so the request is dropped and the caller sees a timeout / empty result (#170, #222).

`send()`'s `list` handler already serialises a `TagValue` list to the `tag=value;` string the server expects, so the separate count field is redundant and breaks parsing. Removing it is the fix.

**Verified against a live IB Gateway (serverVersion 157):**

- Before: both calls → `Error 320`, empty result.
- After:
  - `calculateImpliedVolatility` → `OptionComputation(impliedVol=0.302, optPrice=3.6, undPrice=315.0)`
  - `calculateOptionPrice` → `OptionComputation(optPrice=3.567, delta=0.51, gamma=0.045, vega=0.117, theta=-0.57, impliedVol=0.3)`
- Non-empty options now parse as key=value (server validates keys rather than erroring on the format).

Fixes #222, #170.
