### PR TITLE
Handle formatDate=3 historical bar timestamps

### DIFF
--- a/ib_async/decoder.py
+++ b/ib_async/decoder.py
@@ -478,9 +478,32 @@ class Decoder:
         _, reqId, startDateStr, endDateStr, numBars, *fields = fields
         get = iter(fields).__next__
 
+        start: datetime | None = None
+        end: datetime | None = None
+
         for _ in range(int(numBars)):
+            date = get()
+            if (
+                isinstance(date, str)
+                and date.count(" ") >= 2
+                and "  " not in date
+                and len(date.split(" ", 1)[0]) == 4
+            ):
+                if start is None:
+                    parsedStart = parseIBDatetime(startDateStr)
+                    parsedEnd = parseIBDatetime(endDateStr)
+                    if not isinstance(parsedStart, datetime) or not isinstance(
+                        parsedEnd, datetime
+                    ):
+                        raise ValueError(
+                            "IB formatDate=3 bars require full datetime response bounds"
+                        )
+                    start = parsedStart
+                    end = parsedEnd
+                date = parseIBDatetime(date, start=start, end=end)
+
             bar = BarData(
-                date=get(),
+                date=date,
                 open=float(get()),
                 high=float(get()),
                 low=float(get()),

--- a/ib_async/util.py
+++ b/ib_async/util.py
@@ -590,8 +590,69 @@ def formatIBDatetime(t: dt.date | dt.datetime | str | None) -> str:
     return s
 
 
-def parseIBDatetime(s: str) -> dt.date | dt.datetime:
-    """Parse string in IB date or datetime format to datetime."""
+def _parseIBShortDatetime(
+    s: str,
+    s0: str,
+    s1: str,
+    s2: str,
+    start: dt.datetime | None,
+    end: dt.datetime | None,
+) -> dt.datetime:
+    """Parse an IB formatDate=3 value with an explicitly supplied context."""
+    if start is None and end is None:
+        raise ValueError(
+            f"Cannot infer year for IB datetime {s!r} without a response range"
+        )
+    if start is None or end is None:
+        raise ValueError(
+            "Both start and end are required to parse an IB short datetime"
+        )
+
+    try:
+        tz = ZoneInfo(s2)
+        monthDay = dt.datetime.strptime(s0 + s1, "%m%d%H:%M:%S").replace(tzinfo=tz)
+    except (ValueError, TypeError, KeyError) as exc:
+        raise ValueError(f"Invalid IB short datetime {s!r}") from exc
+
+    def withTimezone(value: dt.datetime) -> dt.datetime:
+        return value if value.tzinfo else value.replace(tzinfo=tz)
+
+    candidates: list[dt.datetime] = []
+    start = withTimezone(start)
+    end = withTimezone(end)
+    if start > end:
+        raise ValueError(f"Invalid IB historical date range: {start!r} > {end!r}")
+
+    for year in range(min(start.year, end.year) - 1, max(start.year, end.year) + 2):
+        try:
+            candidate = monthDay.replace(year=year)
+        except ValueError:
+            # 02/29 is only valid in leap years.
+            continue
+        if start <= candidate <= end:
+            candidates.append(candidate)
+    if len(candidates) != 1:
+        if not candidates:
+            reason = "no candidate falls within the supplied context"
+        else:
+            reason = f"{len(candidates)} candidates match the supplied context"
+        raise ValueError(f"Cannot infer year for IB datetime {s!r}: {reason}")
+
+    return candidates[0]
+
+
+def parseIBDatetime(
+    s: str,
+    *,
+    start: dt.datetime | None = None,
+    end: dt.datetime | None = None,
+) -> dt.date | dt.datetime:
+    """Parse string in IB date or datetime format to datetime.
+
+    IB's ``formatDate=3`` values contain only ``MMDD``.  Such values are
+    parsed only when a full response range (``start`` and ``end``) is
+    supplied; the current year is never used as a fallback.
+    """
     if len(s) == 8:
         # YYYYmmdd
         y = int(s[0:4])
@@ -603,8 +664,11 @@ def parseIBDatetime(s: str) -> dt.date | dt.datetime:
     elif s.count(" ") >= 2 and "  " not in s:
         # 20221125 10:00:00 Europe/Amsterdam
         s0, s1, s2 = s.split(" ", 2)
-        t = dt.datetime.strptime(s0 + s1, "%Y%m%d%H:%M:%S")
-        t = t.replace(tzinfo=ZoneInfo(s2))
+        if len(s0) == 4:
+            t = _parseIBShortDatetime(s, s0, s1, s2, start, end)
+        else:
+            t = dt.datetime.strptime(s0 + s1, "%Y%m%d%H:%M:%S")
+            t = t.replace(tzinfo=ZoneInfo(s2))
     else:
         # YYYYmmdd  HH:MM:SS
         # or

--- a/ib_async/wrapper.py
+++ b/ib_async/wrapper.py
@@ -914,7 +914,8 @@ class Wrapper:
     def historicalData(self, reqId: int, bar: BarData):
         results = self._results.get(reqId)
         if results is not None:
-            bar.date = parseIBDatetime(bar.date)  # type: ignore
+            if isinstance(bar.date, str):
+                bar.date = parseIBDatetime(bar.date)
             results.append(bar)
 
     def historicalDataEnd(self, reqId, _start: str, _end: str):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,0 +1,122 @@
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from ib_async.decoder import Decoder
+from ib_async.objects import BarData
+from ib_async.util import parseIBDatetime
+
+EASTERN = ZoneInfo("US/Eastern")
+
+
+def _full(value: str) -> dt.datetime:
+    parsed = parseIBDatetime(value)
+    assert isinstance(parsed, dt.datetime)
+    return parsed
+
+
+def test_parse_format_date_3_uses_response_year() -> None:
+    start = _full("20250714 08:59:54 US/Eastern")
+    end = _full("20250715 08:59:54 US/Eastern")
+
+    parsed = parseIBDatetime(
+        "0714 09:30:00 US/Eastern",
+        start=start,
+        end=end,
+    )
+
+    assert parsed == dt.datetime(2025, 7, 14, 9, 30, tzinfo=EASTERN)
+
+
+def test_parse_format_date_3_handles_year_rollover() -> None:
+    start = _full("20241231 00:00:00 US/Eastern")
+    end = _full("20250102 00:00:00 US/Eastern")
+
+    assert (
+        parseIBDatetime("1231 23:30:00 US/Eastern", start=start, end=end).year == 2024
+    )
+    assert (
+        parseIBDatetime("0101 00:30:00 US/Eastern", start=start, end=end).year == 2025
+    )
+
+
+def test_parse_format_date_3_rejects_ambiguous_year() -> None:
+    start = _full("20240101 00:00:00 US/Eastern")
+    end = _full("20250102 00:00:00 US/Eastern")
+
+    with pytest.raises(ValueError, match="2 candidates"):
+        parseIBDatetime("0101 00:30:00 US/Eastern", start=start, end=end)
+
+
+def test_parse_format_date_3_rejects_date_outside_response_range() -> None:
+    start = _full("20250714 08:59:54 US/Eastern")
+    end = _full("20250715 08:59:54 US/Eastern")
+
+    with pytest.raises(ValueError, match="no candidate"):
+        parseIBDatetime("0713 09:30:00 US/Eastern", start=start, end=end)
+
+
+def test_parse_format_date_3_requires_context() -> None:
+    with pytest.raises(ValueError, match="without a response range"):
+        parseIBDatetime("0714 09:30:00 US/Eastern")
+
+
+def test_existing_datetime_formats_are_unchanged() -> None:
+    assert parseIBDatetime("20250714") == dt.date(2025, 7, 14)
+    assert parseIBDatetime("1752501600") == dt.datetime.fromtimestamp(
+        1752501600, dt.timezone.utc
+    )
+    assert parseIBDatetime("20250714 09:30:00 US/Eastern") == dt.datetime(
+        2025, 7, 14, 9, 30, tzinfo=EASTERN
+    )
+
+
+class _RecordingWrapper:
+    def __init__(self) -> None:
+        self.bars: list[BarData] = []
+        self.end: tuple[int, str, str] | None = None
+
+    def historicalData(self, reqId: int, bar: BarData) -> None:
+        self.bars.append(bar)
+
+    def historicalDataEnd(self, reqId: int, start: str, end: str) -> None:
+        self.end = (reqId, start, end)
+
+
+def test_decoder_parses_short_bars_before_wrapper() -> None:
+    wrapper = _RecordingWrapper()
+    decoder = Decoder(wrapper, serverVersion=177)
+    start = "20250714 08:59:54 US/Eastern"
+    end = "20250715 08:59:54 US/Eastern"
+    fields = [
+        "17",
+        "6",
+        start,
+        end,
+        "2",
+        "0714 09:30:00 US/Eastern",
+        "209.93",
+        "210.91",
+        "207.67",
+        "207.89",
+        "5583527",
+        "208.961",
+        "28611",
+        "0714 10:00:00 US/Eastern",
+        "207.90",
+        "208.78",
+        "207.54",
+        "208.03",
+        "2978782",
+        "208.082",
+        "16926",
+    ]
+
+    decoder.historicalData(fields)
+
+    assert [bar.date for bar in wrapper.bars] == [
+        dt.datetime(2025, 7, 14, 9, 30, tzinfo=EASTERN),
+        dt.datetime(2025, 7, 14, 10, 0, tzinfo=EASTERN),
+    ]
+    assert wrapper.end == (6, start, end)


### PR DESCRIPTION
## Summary

- use the historical response bounds to recover the year omitted by `formatDate=3`
- handle year boundaries and reject ambiguous ranges instead of guessing the current year
- avoid reparsing dates already decoded with response context
- add regression coverage for the reported payload and existing date formats

## Tests

- `uv run pytest -q -s tests/test_datetime.py` (7 passed)
- `uv run mypy ib_async/util.py ib_async/decoder.py ib_async/wrapper.py`
- `uv run ruff check ib_async/util.py ib_async/decoder.py ib_async/wrapper.py tests/test_datetime.py`
- `uv run ruff format --check ib_async/util.py ib_async/decoder.py ib_async/wrapper.py tests/test_datetime.py`
- `git diff --check`

Closes #161.